### PR TITLE
Update Setup Script - Added compatibility with Fedora - new-branch2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The `ionet-setup.sh` script performs a series of operations:
 
 - Ubuntu (20.04, 22.04, 18.04)
 - Debian (10, 11)
+- Fedora (38, 39)
 
 ## Contributions
 

--- a/ionet-setup.sh
+++ b/ionet-setup.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-# @dev Removed the selection state of `cloud-init` package, as it is dispensable and prevents errors on other Distros
+sudo dpkg --set-selections <<< "cloud-init install" || true
 
 # Set Gloabal Variables
 # Detect OS
@@ -34,7 +34,7 @@ else
     if command -v nvidia-smi &>/dev/null; then
         echo "CUDA drivers already installed as nvidia-smi works."
         if [ "$DISTRO" = "fedora" ]; then
-            # @dev Remove uncompatible versions of docker
+            # @dev Remove incompatible versions of docker
             if command -v docker &>/dev/null; then
                 sudo dnf remove moby-engine -y || true
             fi
@@ -177,7 +177,7 @@ else
             case $VERSION in
             "38" | "39")
                 # Commands specific to Fedora
-                # @dev Remove uncompatible versions of docker
+                # @dev Remove incompatible versions of docker
                 if command -v docker &>/dev/null; then
                     sudo dnf remove moby-engine -y || true
                 fi

--- a/ionet-setup.sh
+++ b/ionet-setup.sh
@@ -2,27 +2,26 @@
 
 set -euxo pipefail
 
-
 export DEBIAN_FRONTEND=noninteractive
 
 # @dev Removed the selection state of `cloud-init` package, as it is dispensable and prevents errors on other Distros
 
 # Set Gloabal Variables
-    # Detect OS
-        OS="$(uname)"
-        case $OS in
-            "Linux")
-                # Detect Linux Distro
-                if [ -f /etc/os-release ]; then
-                    . /etc/os-release
-                    DISTRO=$ID
-                    VERSION=$VERSION_ID
-                else
-                    echo "Your Linux distribution is not supported."
-                    exit 1
-                fi
-                ;;
-        esac
+# Detect OS
+OS="$(uname)"
+case $OS in
+"Linux")
+    # Detect Linux Distro
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        DISTRO=$ID
+        VERSION=$VERSION_ID
+    else
+        echo "Your Linux distribution is not supported."
+        exit 1
+    fi
+    ;;
+esac
 
 # Detect if an Nvidia GPU is present
 NVIDIA_PRESENT=$(lspci | grep -i nvidia || true)
@@ -31,195 +30,196 @@ NVIDIA_PRESENT=$(lspci | grep -i nvidia || true)
 if [[ -z "$NVIDIA_PRESENT" ]]; then
     echo "No NVIDIA device detected on this system."
 else
-# Check if nvidia-smi is available and working
+    # Check if nvidia-smi is available and working
     if command -v nvidia-smi &>/dev/null; then
         echo "CUDA drivers already installed as nvidia-smi works."
+        if [ "$DISTRO" = "fedora" ]; then
+            # @dev Remove uncompatible versions of docker
+            if command -v docker &>/dev/null; then
+                sudo dnf remove moby-engine -y || true
+            fi
+        fi
     else
 
-                # Depending on Distro
-                case $DISTRO in
-                    "ubuntu")
-                        case $VERSION in
-                            "20.04")
-                                # Commands specific to Ubuntu 20.04
-                                sudo -- sh -c 'apt-get update; apt-get upgrade -y; apt-get autoremove -y; apt-get autoclean -y'
-                                sudo -- sh -c 'apt-get update; apt-get upgrade -y; apt-get autoremove -y; apt-get autoclean -y'
-                                sudo apt install linux-headers-$(uname -r) -y
-				sudo apt del 7fa2af80 || true
-                                sudo apt remove 7fa2af80 || true
-                                sudo apt install build-essential cmake gpg unzip pkg-config software-properties-common ubuntu-drivers-common -y
-                                sudo apt install libxmu-dev libxi-dev libglu1-mesa libglu1-mesa-dev -y || true
-                                sudo apt install libjpeg-dev libpng-dev libtiff-dev -y || true
-                                sudo apt install libavcodec-dev libavformat-dev libswscale-dev libv4l-dev -y || true
-                                sudo apt install libxvidcore-dev libx264-dev -y || true
-                                sudo apt install libopenblas-dev libatlas-base-dev liblapack-dev gfortran -y || true
-                                sudo apt install libhdf5-serial-dev -y || true
-                                sudo apt install python3-dev python3-tk python-imaging-tk curl cuda-keyring gnupg-agent dirmngr alsa-utils -y || true
-                                sudo apt install libgtk-3-dev -y || true
-                                sudo apt update -y
-                                sudo dirmngr </dev/null
-                                if sudo apt-add-repository -y ppa:graphics-drivers/ppa && sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FCAE110B1118213C; then
-                                    echo "Alternative method succeeded."
-                                else
-                                    echo "Alternative method failed. Trying the original method..."
-                                    sudo dirmngr </dev/null
-                                    sudo apt-add-repository -y ppa:graphics-drivers/ppa
-                                    sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/graphics-drivers.gpg --keyserver keyserver.ubuntu.com --recv-keys FCAE110B1118213C
-                                    sudo chmod 644 /etc/apt/trusted.gpg.d/graphics-drivers.gpg
-                                fi
-                                sudo ubuntu-drivers autoinstall
-                                sudo apt update -y
-                                wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.1-1_all.deb
-                                sudo dpkg -i cuda-keyring_1.1-1_all.deb
-                                sudo apt update -y
-                                sudo apt -y install cuda-toolkit
-                                export LD_LIBRARY_PATH=/usr/local/cuda-12.2/lib64:${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-                                sudo apt-get update
-                                ;;
-                            
-                            "22.04")
-                                # Commands specific to Ubuntu 22.04
-                                sudo -- sh -c 'apt-get update; apt-get upgrade -y; apt-get autoremove -y; apt-get autoclean -y'
-                                sudo -- sh -c 'apt-get update; apt-get upgrade -y; apt-get autoremove -y; apt-get autoclean -y'
-                                sudo apt install linux-headers-$(uname -r) -y
-                                sudo apt del 7fa2af80 || true
-                                sudo apt remove 7fa2af80 || true
-                                sudo apt install build-essential cmake gpg unzip pkg-config software-properties-common ubuntu-drivers-common -y
-                                sudo apt install libxmu-dev libxi-dev libglu1-mesa libglu1-mesa-dev -y
-                                sudo apt install libjpeg-dev libpng-dev libtiff-dev -y 
-                                sudo apt install libavcodec-dev libavformat-dev libswscale-dev libv4l-dev -y 
-                                sudo apt install libxvidcore-dev libx264-dev -y
-                                sudo apt install libopenblas-dev libatlas-base-dev liblapack-dev gfortran -y 
-                                sudo apt install libhdf5-serial-dev -y 
-                                sudo apt install python3-dev python3-tk curl gnupg-agent dirmngr alsa-utils -y
-                                sudo apt install libgtk-3-dev -y 
-                                sudo apt update -y
-                                sudo dirmngr </dev/null
-                                if sudo apt-add-repository -y ppa:graphics-drivers/ppa && sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FCAE110B1118213C; then
-                                    echo "Alternative method succeeded."
-                                else
-                                    echo "Alternative method failed. Trying the original method..."
-                                    sudo dirmngr </dev/null
-                                    sudo apt-add-repository -y ppa:graphics-drivers/ppa
-                                    sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/graphics-drivers.gpg --keyserver keyserver.ubuntu.com --recv-keys FCAE110B1118213C
-                                    sudo chmod 644 /etc/apt/trusted.gpg.d/graphics-drivers.gpg
-                                fi
-                                sudo ubuntu-drivers autoinstall
-                                sudo apt update -y
-                                wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
-                                sudo dpkg -i cuda-keyring_1.1-1_all.deb
-                                sudo apt update -y
-                                sudo apt -y install cuda-toolkit
-                                export LD_LIBRARY_PATH=/usr/local/cuda-12.2/lib64:${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-                                sudo apt update -y
-                                ;;
-
-                            "18.04")
-                                # Commands specific to Ubuntu 18.04
-                                sudo -- sh -c 'apt-get update; apt-get upgrade -y; apt-get autoremove -y; apt-get autoclean -y'
-                                sudo apt-get install linux-headers-$(uname -r) -y
-                                sudo apt del 7fa2af80 || true
-                                sudo apt remove 7fa2af80 || true
-                                sudo apt install build-essential cmake gpg unzip pkg-config software-properties-common ubuntu-drivers-common alsa-utils -y
-                                sudo apt install libxmu-dev libxi-dev libglu1-mesa libglu1-mesa-dev -y || true
-                                sudo apt install libjpeg-dev libpng-dev libtiff-dev -y || true
-                                sudo apt install libavcodec-dev libavformat-dev libswscale-dev libv4l-dev -y || true
-                                sudo apt install libxvidcore-dev libx264-dev -y || true
-                                sudo apt install libopenblas-dev libatlas-base-dev liblapack-dev gfortran -y || true
-                                sudo apt install libhdf5-serial-dev -y || true
-                                sudo apt install python3-dev python3-tk python-imaging-tk curl cuda-keyring -y || true
-                                sudo apt install libgtk-3-dev -y || true
-                                sudo apt update -y
-                                sudo ubuntu-drivers install
-                                sudo apt update -y
-                                wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
-                                sudo dpkg -i cuda-keyring_1.1-1_all.deb
-                                sudo apt update -y
-                                sudo apt -y install cuda-toolkit
-                                export LD_LIBRARY_PATH=/usr/local/cuda-12.2/lib64:${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-                                sudo apt update -y
-                                ;;
-
-                            *)
-                                echo "This version of Ubuntu is not supported in this script."
-                                exit 1
-                                ;;
-                        esac
-                        ;;
-                    
-                    "debian")
-                        case $VERSION in
-                            "10"|"11")
-                                # Commands specific to Debian 10 & 11
-                                sudo -- sh -c 'apt update; apt upgrade -y; apt autoremove -y; apt autoclean -y'
-                                sudo apt install linux-headers-$(uname -r) -y
-                                sudo apt update -y
-                                sudo apt install nvidia-driver firmware-misc-nonfree
-                                wget https://developer.download.nvidia.com/compute/cuda/repos/debian${VERSION}/x86_64/cuda-keyring_1.1-1_all.deb
-                                sudo apt install nvidia-cuda-dev nvidia-cuda-toolkit
-                                sudo apt update -y
-                                ;;
-
-                            *)
-                                echo "This version of Debian is not supported in this script."
-                                exit 1
-                                ;;
-                        esac
-                        ;;
-
-                    *)
-                        echo "Your Linux distribution is not supported."
-                        exit 1
-                        ;;
-
-		     # @dev Added the following code lines to install dependencies in Fedora distros
-		     "fedora")
-                        case $VERSION in
-                            "38"|"39")
-                                # Commands specific to Fedora
-				                # @dev Remove uncompatible versions of docker
-                                sudo dnf remove moby-engine -y || true
-                                sudo dnf update -y
-                                sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm -y || true
-                                sudo dnf install https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm -y || true
-                                sudo dnf makecache -y
-                                sudo dnf update -y
-                                sudo dnf install akmod-nvidia xorg-x11-drv-nvidia-cuda -y || true
-                                sudo dnf autoremove -y
-                                ;;
-
-                            *)
-                                echo "This version of Fedora is not supported in this script."
-                                exit 1
-                                ;;
-                        esac
-                        ;;
-
-                    *)
-                        echo "Your Linux distribution is not supported."
-                        exit 1
-                        ;;
-		     
-            "Windows_NT")
-                # For Windows Subsystem for Linux (WSL) with Ubuntu
-                if grep -q Microsoft /proc/version; then
-                    wget https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/cuda-keyring_1.1-1_all.deb
-                    sudo dpkg -i cuda-keyring_1.1-1_all.deb
-                    sudo apt-get update
-                    sudo apt-get -y install cuda
+        # Depending on Distro
+        case $DISTRO in
+        "ubuntu")
+            case $VERSION in
+            "20.04")
+                # Commands specific to Ubuntu 20.04
+                sudo -- sh -c 'apt-get update; apt-get upgrade -y; apt-get autoremove -y; apt-get autoclean -y'
+                sudo -- sh -c 'apt-get update; apt-get upgrade -y; apt-get autoremove -y; apt-get autoclean -y'
+                sudo apt install linux-headers-$(uname -r) -y
+                sudo apt del 7fa2af80 || true
+                sudo apt remove 7fa2af80 || true
+                sudo apt install build-essential cmake gpg unzip pkg-config software-properties-common ubuntu-drivers-common -y
+                sudo apt install libxmu-dev libxi-dev libglu1-mesa libglu1-mesa-dev -y || true
+                sudo apt install libjpeg-dev libpng-dev libtiff-dev -y || true
+                sudo apt install libavcodec-dev libavformat-dev libswscale-dev libv4l-dev -y || true
+                sudo apt install libxvidcore-dev libx264-dev -y || true
+                sudo apt install libopenblas-dev libatlas-base-dev liblapack-dev gfortran -y || true
+                sudo apt install libhdf5-serial-dev -y || true
+                sudo apt install python3-dev python3-tk python-imaging-tk curl cuda-keyring gnupg-agent dirmngr alsa-utils -y || true
+                sudo apt install libgtk-3-dev -y || true
+                sudo apt update -y
+                sudo dirmngr </dev/null
+                if sudo apt-add-repository -y ppa:graphics-drivers/ppa && sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FCAE110B1118213C; then
+                    echo "Alternative method succeeded."
                 else
-                    echo "This bash script can't be executed on Windows directly unless using WSL with Ubuntu. For other scenarios, consider using a PowerShell script or manual installation."
-                    exit 1
+                    echo "Alternative method failed. Trying the original method..."
+                    sudo dirmngr </dev/null
+                    sudo apt-add-repository -y ppa:graphics-drivers/ppa
+                    sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/graphics-drivers.gpg --keyserver keyserver.ubuntu.com --recv-keys FCAE110B1118213C
+                    sudo chmod 644 /etc/apt/trusted.gpg.d/graphics-drivers.gpg
                 fi
+                sudo ubuntu-drivers autoinstall
+                sudo apt update -y
+                wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.1-1_all.deb
+                sudo dpkg -i cuda-keyring_1.1-1_all.deb
+                sudo apt update -y
+                sudo apt -y install cuda-toolkit
+                export LD_LIBRARY_PATH=/usr/local/cuda-12.2/lib64:${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+                sudo apt-get update
+                ;;
+
+            "22.04")
+                # Commands specific to Ubuntu 22.04
+                sudo -- sh -c 'apt-get update; apt-get upgrade -y; apt-get autoremove -y; apt-get autoclean -y'
+                sudo -- sh -c 'apt-get update; apt-get upgrade -y; apt-get autoremove -y; apt-get autoclean -y'
+                sudo apt install linux-headers-$(uname -r) -y
+                sudo apt del 7fa2af80 || true
+                sudo apt remove 7fa2af80 || true
+                sudo apt install build-essential cmake gpg unzip pkg-config software-properties-common ubuntu-drivers-common -y
+                sudo apt install libxmu-dev libxi-dev libglu1-mesa libglu1-mesa-dev -y
+                sudo apt install libjpeg-dev libpng-dev libtiff-dev -y
+                sudo apt install libavcodec-dev libavformat-dev libswscale-dev libv4l-dev -y
+                sudo apt install libxvidcore-dev libx264-dev -y
+                sudo apt install libopenblas-dev libatlas-base-dev liblapack-dev gfortran -y
+                sudo apt install libhdf5-serial-dev -y
+                sudo apt install python3-dev python3-tk curl gnupg-agent dirmngr alsa-utils -y
+                sudo apt install libgtk-3-dev -y
+                sudo apt update -y
+                sudo dirmngr </dev/null
+                if sudo apt-add-repository -y ppa:graphics-drivers/ppa && sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FCAE110B1118213C; then
+                    echo "Alternative method succeeded."
+                else
+                    echo "Alternative method failed. Trying the original method..."
+                    sudo dirmngr </dev/null
+                    sudo apt-add-repository -y ppa:graphics-drivers/ppa
+                    sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/graphics-drivers.gpg --keyserver keyserver.ubuntu.com --recv-keys FCAE110B1118213C
+                    sudo chmod 644 /etc/apt/trusted.gpg.d/graphics-drivers.gpg
+                fi
+                sudo ubuntu-drivers autoinstall
+                sudo apt update -y
+                wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+                sudo dpkg -i cuda-keyring_1.1-1_all.deb
+                sudo apt update -y
+                sudo apt -y install cuda-toolkit
+                export LD_LIBRARY_PATH=/usr/local/cuda-12.2/lib64:${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+                sudo apt update -y
+                ;;
+
+            "18.04")
+                # Commands specific to Ubuntu 18.04
+                sudo -- sh -c 'apt-get update; apt-get upgrade -y; apt-get autoremove -y; apt-get autoclean -y'
+                sudo apt-get install linux-headers-$(uname -r) -y
+                sudo apt del 7fa2af80 || true
+                sudo apt remove 7fa2af80 || true
+                sudo apt install build-essential cmake gpg unzip pkg-config software-properties-common ubuntu-drivers-common alsa-utils -y
+                sudo apt install libxmu-dev libxi-dev libglu1-mesa libglu1-mesa-dev -y || true
+                sudo apt install libjpeg-dev libpng-dev libtiff-dev -y || true
+                sudo apt install libavcodec-dev libavformat-dev libswscale-dev libv4l-dev -y || true
+                sudo apt install libxvidcore-dev libx264-dev -y || true
+                sudo apt install libopenblas-dev libatlas-base-dev liblapack-dev gfortran -y || true
+                sudo apt install libhdf5-serial-dev -y || true
+                sudo apt install python3-dev python3-tk python-imaging-tk curl cuda-keyring -y || true
+                sudo apt install libgtk-3-dev -y || true
+                sudo apt update -y
+                sudo ubuntu-drivers install
+                sudo apt update -y
+                wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+                sudo dpkg -i cuda-keyring_1.1-1_all.deb
+                sudo apt update -y
+                sudo apt -y install cuda-toolkit
+                export LD_LIBRARY_PATH=/usr/local/cuda-12.2/lib64:${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+                sudo apt update -y
                 ;;
 
             *)
-                echo "Your OS is not supported."
+                echo "This version of Ubuntu is not supported in this script."
                 exit 1
                 ;;
+            esac
+            ;;
+
+        "debian")
+            case $VERSION in
+            "10" | "11")
+                # Commands specific to Debian 10 & 11
+                sudo -- sh -c 'apt update; apt upgrade -y; apt autoremove -y; apt autoclean -y'
+                sudo apt install linux-headers-$(uname -r) -y
+                sudo apt update -y
+                sudo apt install nvidia-driver firmware-misc-nonfree
+                wget https://developer.download.nvidia.com/compute/cuda/repos/debian${VERSION}/x86_64/cuda-keyring_1.1-1_all.deb
+                sudo apt install nvidia-cuda-dev nvidia-cuda-toolkit
+                sudo apt update -y
+                ;;
+
+            *)
+                echo "This version of Debian is not supported in this script."
+                exit 1
+                ;;
+            esac
+            ;;
+
+        # @dev Added the following code lines to install dependencies in Fedora distros
+        "fedora")
+            case $VERSION in
+            "38" | "39")
+                # Commands specific to Fedora
+                # @dev Remove uncompatible versions of docker
+                if command -v docker &>/dev/null; then
+                    sudo dnf remove moby-engine -y || true
+                fi
+                sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm -y || true
+                sudo dnf install https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm -y || true
+                sudo dnf update -y
+                sudo dnf install akmod-nvidia xorg-x11-drv-nvidia-cuda -y || true
+                sudo dnf autoremove -y
+                ;;
+
+            *)
+                echo "This version of Fedora is not supported in this script."
+                exit 1
+                ;;
+            esac
+            ;;
+
+        *)
+            echo "Your Linux distribution is not supported."
+            exit 1
+            ;;
+
+        "Windows_NT")
+            # For Windows Subsystem for Linux (WSL) with Ubuntu
+            if grep -q Microsoft /proc/version; then
+                wget https://developer.download.nvidia.com/compute/cuda/repos/wsl-ubuntu/x86_64/cuda-keyring_1.1-1_all.deb
+                sudo dpkg -i cuda-keyring_1.1-1_all.deb
+                sudo apt-get update
+                sudo apt-get -y install cuda
+            else
+                echo "This bash script can't be executed on Windows directly unless using WSL with Ubuntu. For other scenarios, consider using a PowerShell script or manual installation."
+                exit 1
+            fi
+            ;;
+
+        *)
+            echo "Your OS is not supported."
+            exit 1
+            ;;
         esac
-	echo "System will now reboot !!! Please re-run this script after restart to complete installation !"
- 	sleep 5s
+        echo "System will now reboot !!! Please re-run this script after restart to complete installation !"
+        sleep 5s
         sudo reboot
     fi
 fi
@@ -232,15 +232,12 @@ fi
 if command -v docker &>/dev/null; then
     echo "Docker is already installed."
 # @dev Added the following code lines to install dependencies in Fedora distros
-elif [["$DISTRO" == "fedora"]]; then
+elif [ "$DISTRO" = "fedora" ]; then
     echo "Docker is not installed. Proceeding with installations..."
     sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo || true
-    sudo dnf update -y || true
-    sudo dnf install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y || true
+    sudo dnf update -y
     # @dev One assumes that if docker isn't installed, we'll install every docker related dependecies
-    curl -s -L https://nvidia.github.io/libnvidia-container/centos8/libnvidia-container.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo || true
-    sudo dnf update -y || true
-    sudo dnf install nvidia-docker2 -y || true
+    sudo dnf install docker-ce docker-ce-cli containerd.io docker-compose-plugin -y || true
     sudo dnf autoremove -y
 else
     echo "Docker is not installed. Proceeding with installations..."
@@ -257,9 +254,12 @@ else
 
     # Add Docker-ce repository to Apt sources and install
     echo \
-      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-      $(. /etc/os-release; echo "$VERSION_CODENAME") stable" | \
-      sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+      $(
+            . /etc/os-release
+            echo "$VERSION_CODENAME"
+        ) stable" |
+        sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
     sudo apt update -y
     sudo apt -y install docker-ce
 fi
@@ -268,7 +268,7 @@ fi
 if command -v docker-compose &>/dev/null; then
     echo "Docker-compose is already installed."
 # @dev Added the following code lines to install dependencies in Fedora distros
-elif [["$DISTRO" == "fedora"]]; then
+elif [ "$DISTRO" = "fedora" ]; then
     echo "Docker-compose is not installed. Proceeding with installations..."
     sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo || true
     sudo dnf update -y
@@ -286,17 +286,20 @@ fi
 if [[ ! -z "$NVIDIA_PRESENT" ]]; then
     if sudo docker run --gpus all nvidia/cuda:11.0.3-base-ubuntu18.04 nvidia-smi &>/dev/null; then
         echo "nvidia-docker is enabled and working. Exiting script."
-    # @dev Added the following code lines to install dependencies in Fedora distros	
-    elif [["$DISTRO" == "fedora"]]; then
+    # @dev Added the following code lines to install dependencies in Fedora distros
+    elif [ "$DISTRO" = "fedora" ]; then
         echo "nvidia-docker is not installed. Proceeding with installations..."
-	# @dev Tested the following repo and it works fine in Fedora 38 and 39
+        # @dev Tested the following repo and it works fine in Fedora 38 and 39
         curl -s -L https://nvidia.github.io/libnvidia-container/centos8/libnvidia-container.repo | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo || true
-        sudo dnf update -y || true
+        sudo dnf update -y
         sudo dnf install nvidia-docker2 -y || true
         sudo dnf autoremove -y
     else
         echo "nvidia-docker does not seem to be enabled. Proceeding with installations..."
-        distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+        distribution=$(
+            . /etc/os-release
+            echo $ID$VERSION_ID
+        )
         curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add
         curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
         sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit


### PR DESCRIPTION
In the new-branch2, the setup script has been updated for compatibility with the Fedora distribution.

Comments mentioning `@dev` in `./ionet-setup.sh`

Removed: 

```
sudo apt-mark hold nvidia* libnvidia*
```
