### PR TITLE
Remove unnecessary `newgrp` which created new shell effectively stopping the script

### DIFF
--- a/ionet-setup.sh
+++ b/ionet-setup.sh
@@ -253,7 +253,6 @@ sudo apt-mark hold nvidia* libnvidia*
 # Add docker group and user to group docker
 sudo groupadd docker || true
 sudo usermod -aG docker $USER || true
-newgrp docker || true
 # Workaround for NVIDIA Docker Issue
 echo "Applying workaround for NVIDIA Docker issue as per https://github.com/NVIDIA/nvidia-docker/issues/1730"
 # Summary of issue and workaround:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed unnecessary group switching in the setup script for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->